### PR TITLE
fix: Update @apollo/link-schema for graphql 16 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@apollo/client": "^3.12.5",
     "@apollo/link-error": "^2.0.0-beta.3",
-    "@apollo/link-schema": "^2.0.0-beta.3",
+    "@apollo/link-schema": "^3.0.0",
     "@auth0/nextjs-auth0": "^3.5.0",
     "@graphql-tools/schema": "^10.0.16",
     "@headlessui/react": "^2.2.0",


### PR DESCRIPTION
## Fix

Update @apollo/link-schema from ^2.0.0-beta.3 to ^3.0.0 to fix peer dependency conflict with graphql 16.10.0.

Required for PR #26 (Neon migration) to build successfully.