### PR TITLE
Fix: Remove global.fetch polyfill and ignoreBuildErrors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,12 +5,6 @@ module.exports = withPlausibleProxy()({
   images: {
     domains: ['pbs.twimg.com', 'abs.twimg.com', 'imagedelivery.net'],
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/src/lib/apollo/index.ts
+++ b/src/lib/apollo/index.ts
@@ -14,7 +14,6 @@ import toast from 'react-hot-toast'
 
 import { APOLLO_STATE_PROP_NAME, GRAPHQL_ENDPOINT } from '~/graphql/constants'
 
-global.fetch = require('node-fetch')
 let apolloClient
 
 function createIsomorphLink({ context }) {


### PR DESCRIPTION
## Changes

- Remove unnecessary `global.fetch = require('node-fetch')` (fetch is global in Node 18+/Next.js 14+)
- Remove `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` to catch actual build errors
- These settings were masking real issues and should be fixed properly instead

## Testing

- [ ] Run `yarn install` to install dependencies
- [ ] Run `yarn build` to verify build succeeds without ignored errors