### PR TITLE
feat(photographs): add admin-curated photograph gallery

### DIFF
--- a/prisma/migrations/20260427000000_add_photograph/migration.sql
+++ b/prisma/migrations/20260427000000_add_photograph/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable
+CREATE TABLE "Photograph" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "publishedAt" TIMESTAMP(3),
+    "slug" VARCHAR(96) NOT NULL,
+    "title" VARCHAR(140) NOT NULL,
+    "caption" VARCHAR(1024),
+    "imageUrl" VARCHAR(512) NOT NULL,
+    "width" INTEGER NOT NULL,
+    "height" INTEGER NOT NULL,
+    "capturedAt" TIMESTAMP(3),
+    "location" VARCHAR(120),
+    "camera" VARCHAR(80),
+    "lens" VARCHAR(80),
+
+    CONSTRAINT "Photograph_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_PhotographToTag" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Photograph_slug_key" ON "Photograph"("slug");
+
+-- CreateIndex
+CREATE INDEX "Photograph_publishedAt_idx" ON "Photograph"("publishedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PhotographToTag_AB_unique" ON "_PhotographToTag"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PhotographToTag_B_index" ON "_PhotographToTag"("B");
+
+-- AddForeignKey
+ALTER TABLE "_PhotographToTag" ADD CONSTRAINT "_PhotographToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Photograph"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PhotographToTag" ADD CONSTRAINT "_PhotographToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,10 +126,31 @@ model PostEdit {
 }
 
 model Tag {
-  id        String     @id @default(cuid())
-  name      String     @unique
-  bookmarks Bookmark[] @relation("BookmarkToTag")
-  stacks    Stack[]    @relation("StackToTag")
+  id          String       @id @default(cuid())
+  name        String       @unique
+  bookmarks   Bookmark[]   @relation("BookmarkToTag")
+  stacks      Stack[]      @relation("StackToTag")
+  photographs Photograph[] @relation("PhotographToTag")
+}
+
+model Photograph {
+  id          String    @id @default(cuid())
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  publishedAt DateTime?
+  slug        String    @unique @db.VarChar(96)
+  title       String    @db.VarChar(140)
+  caption     String?   @db.VarChar(1024)
+  imageUrl    String    @db.VarChar(512)
+  width       Int
+  height      Int
+  capturedAt  DateTime?
+  location    String?   @db.VarChar(120)
+  camera      String?   @db.VarChar(80)
+  lens        String?   @db.VarChar(80)
+  tags        Tag[]     @relation("PhotographToTag")
+
+  @@index([publishedAt])
 }
 
 model Stack {

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -137,6 +137,24 @@ export function BookmarksIcon() {
   )
 }
 
+export function PhotographsIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      width="16"
+      height="16"
+      fill="currentColor"
+    >
+      <path
+        fillRule="evenodd"
+        d="M4 5h2l1.447-1.447A1 1 0 018.118 3h3.764a1 1 0 01.671.553L13.999 5H16a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V7a2 2 0 012-2zm6 9a3.5 3.5 0 100-7 3.5 3.5 0 000 7z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
+
 export function AMAIcon() {
   return (
     <svg

--- a/src/components/Photographs/AddPhotographDialog.tsx
+++ b/src/components/Photographs/AddPhotographDialog.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+import { DialogComponent } from '~/components/Dialog'
+
+import { AddPhotographForm } from './AddPhotographForm'
+
+export function AddPhotographDialog({ trigger }) {
+  return (
+    <DialogComponent
+      trigger={trigger}
+      title={'New photograph'}
+      modalContent={({ closeModal }) => (
+        <AddPhotographForm closeModal={closeModal} />
+      )}
+    />
+  )
+}

--- a/src/components/Photographs/AddPhotographForm.tsx
+++ b/src/components/Photographs/AddPhotographForm.tsx
@@ -1,0 +1,148 @@
+import { useRouter } from 'next/router'
+import * as React from 'react'
+import slugify from 'slugify'
+
+import { ErrorAlert } from '~/components/Alert'
+import Button from '~/components/Button'
+import { Input, Textarea } from '~/components/Input'
+import { LoadingSpinner } from '~/components/LoadingSpinner'
+import { GET_PHOTOGRAPHS } from '~/graphql/queries/photographs'
+import { useAddPhotographMutation } from '~/graphql/types.generated'
+
+import { PhotographImageUploader } from './PhotographImageUploader'
+
+export function AddPhotographForm({ closeModal }) {
+  const [title, setTitle] = React.useState('')
+  const [slug, setSlug] = React.useState('')
+  const [slugTouched, setSlugTouched] = React.useState(false)
+  const [caption, setCaption] = React.useState('')
+  const [capturedAt, setCapturedAt] = React.useState('')
+  const [location, setLocation] = React.useState('')
+  const [camera, setCamera] = React.useState('')
+  const [lens, setLens] = React.useState('')
+  const [image, setImage] = React.useState<{
+    url: string
+    width: number
+    height: number
+  } | null>(null)
+  const [error, setError] = React.useState('')
+
+  const router = useRouter()
+
+  const [handleAdd, { loading }] = useAddPhotographMutation({
+    onCompleted: ({ addPhotograph }) => {
+      closeModal()
+      if (addPhotograph?.slug) {
+        return router.push(`/photographs/${addPhotograph.slug}`)
+      }
+    },
+    refetchQueries: [{ query: GET_PHOTOGRAPHS }],
+    onError({ message }) {
+      setError(message.replace('GraphQL error:', ''))
+    },
+  })
+
+  function onTitleChange(e) {
+    error && setError('')
+    const value = e.target.value
+    setTitle(value)
+    if (!slugTouched) setSlug(slugify(value, { lower: true, strict: true }))
+  }
+
+  function onSlugChange(e) {
+    error && setError('')
+    setSlugTouched(true)
+    setSlug(e.target.value)
+  }
+
+  function onSubmit(e) {
+    e.preventDefault()
+    if (!image) return setError('Please upload an image')
+    if (!title) return setError('Please enter a title')
+    if (!slug) return setError('Please enter a slug')
+
+    return handleAdd({
+      variables: {
+        data: {
+          title,
+          slug,
+          caption: caption || null,
+          imageUrl: image.url,
+          width: image.width,
+          height: image.height,
+          capturedAt: capturedAt ? new Date(capturedAt).getTime() : null,
+          location: location || null,
+          camera: camera || null,
+          lens: lens || null,
+        },
+      },
+    })
+  }
+
+  function onKeyDown(e) {
+    if (e.keyCode === 13 && e.metaKey) return onSubmit(e)
+  }
+
+  return (
+    <div className="space-y-3 p-4">
+      <PhotographImageUploader onImageUploaded={setImage} />
+      <form className="space-y-3" onSubmit={onSubmit}>
+        <Input
+          type="text"
+          placeholder="Title"
+          value={title}
+          onChange={onTitleChange}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          type="text"
+          placeholder="Slug"
+          value={slug}
+          onChange={onSlugChange}
+          onKeyDown={onKeyDown}
+        />
+        <Textarea
+          rows={3}
+          placeholder="Caption (optional)"
+          value={caption}
+          onChange={(e) => setCaption(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          type="date"
+          placeholder="Captured at"
+          value={capturedAt}
+          onChange={(e) => setCapturedAt(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          type="text"
+          placeholder="Location (e.g. Reykjavík, Iceland)"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          type="text"
+          placeholder="Camera"
+          value={camera}
+          onChange={(e) => setCamera(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          type="text"
+          placeholder="Lens"
+          value={lens}
+          onChange={(e) => setLens(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <div className="flex justify-end">
+          <Button disabled={!image || !title || !slug || loading}>
+            {loading ? <LoadingSpinner /> : 'Save'}
+          </Button>
+        </div>
+        {error && <ErrorAlert>{error}</ErrorAlert>}
+      </form>
+    </div>
+  )
+}

--- a/src/components/Photographs/EditPhotographDialog.tsx
+++ b/src/components/Photographs/EditPhotographDialog.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+import { DialogComponent } from '~/components/Dialog'
+
+import { EditPhotographForm } from './EditPhotographForm'
+
+export function EditPhotographDialog({ trigger, photograph }) {
+  return (
+    <DialogComponent
+      trigger={trigger}
+      title={'Edit photograph'}
+      modalContent={({ closeModal }) => (
+        <EditPhotographForm photograph={photograph} closeModal={closeModal} />
+      )}
+    />
+  )
+}

--- a/src/components/Photographs/EditPhotographForm.tsx
+++ b/src/components/Photographs/EditPhotographForm.tsx
@@ -1,0 +1,157 @@
+import { useRouter } from 'next/router'
+import * as React from 'react'
+
+import Button, { DeleteButton } from '~/components/Button'
+import { Input, Textarea } from '~/components/Input'
+import { GET_PHOTOGRAPHS } from '~/graphql/queries/photographs'
+import {
+  useDeletePhotographMutation,
+  useEditPhotographMutation,
+} from '~/graphql/types.generated'
+
+function toDateInputValue(date: number | string | null | undefined) {
+  if (!date) return ''
+  const d = new Date(date)
+  if (isNaN(d.getTime())) return ''
+  return d.toISOString().slice(0, 10)
+}
+
+export function EditPhotographForm({ closeModal, photograph }) {
+  const router = useRouter()
+
+  const [title, setTitle] = React.useState(photograph.title ?? '')
+  const [slug, setSlug] = React.useState(photograph.slug ?? '')
+  const [caption, setCaption] = React.useState(photograph.caption ?? '')
+  const [capturedAt, setCapturedAt] = React.useState(
+    toDateInputValue(photograph.capturedAt)
+  )
+  const [location, setLocation] = React.useState(photograph.location ?? '')
+  const [camera, setCamera] = React.useState(photograph.camera ?? '')
+  const [lens, setLens] = React.useState(photograph.lens ?? '')
+  const [published, setPublished] = React.useState(
+    Boolean(photograph.publishedAt)
+  )
+  const [error, setError] = React.useState('')
+
+  const [editPhotograph] = useEditPhotographMutation()
+
+  const [handleDelete] = useDeletePhotographMutation({
+    variables: { id: photograph.id },
+    refetchQueries: [{ query: GET_PHOTOGRAPHS }],
+    onCompleted() {
+      closeModal()
+      router.push('/photographs')
+    },
+  })
+
+  function handleSave(e) {
+    e.preventDefault()
+    if (!title) return setError('Photograph must have a title')
+    if (!slug) return setError('Photograph must have a slug')
+
+    editPhotograph({
+      variables: {
+        id: photograph.id,
+        data: {
+          title,
+          slug,
+          caption: caption || null,
+          capturedAt: capturedAt ? new Date(capturedAt).getTime() : null,
+          location: location || null,
+          camera: camera || null,
+          lens: lens || null,
+          published,
+        },
+      },
+      onError({ message }) {
+        setError(message.replace('GraphQL error:', ''))
+      },
+    }).then((res) => {
+      const nextSlug = res?.data?.editPhotograph?.slug
+      closeModal()
+      if (nextSlug && nextSlug !== photograph.slug) {
+        router.push(`/photographs/${nextSlug}`)
+      }
+    })
+  }
+
+  function onKeyDown(e) {
+    if (e.keyCode === 13 && e.metaKey) return handleSave(e)
+  }
+
+  return (
+    <div className="space-y-3 p-4">
+      <form className="space-y-3" onSubmit={handleSave}>
+        <Input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          placeholder="Slug"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Textarea
+          rows={3}
+          placeholder="Caption"
+          value={caption}
+          onChange={(e) => setCaption(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          type="date"
+          placeholder="Captured at"
+          value={capturedAt}
+          onChange={(e) => setCapturedAt(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          placeholder="Camera"
+          value={camera}
+          onChange={(e) => setCamera(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <Input
+          placeholder="Lens"
+          value={lens}
+          onChange={(e) => setLens(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+
+        <label className="flex items-center space-x-2 text-sm text-gray-1000 dark:text-white">
+          <input
+            type="checkbox"
+            checked={published}
+            onChange={(e) => setPublished(e.target.checked)}
+          />
+          <span>Published</span>
+        </label>
+
+        {error && <p className="text-red-500">{error}</p>}
+
+        <div className="flex justify-between">
+          <DeleteButton
+            onClick={() => {
+              closeModal()
+              handleDelete()
+            }}
+          >
+            Delete
+          </DeleteButton>
+          <div className="flex space-x-3">
+            <Button onClick={handleSave}>Save</Button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/Photographs/PhotographActions.tsx
+++ b/src/components/Photographs/PhotographActions.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+import Button from '~/components/Button'
+import { useViewerQuery } from '~/graphql/types.generated'
+
+import { EditPhotographDialog } from './EditPhotographDialog'
+
+export function PhotographActions({ photograph }) {
+  const { data } = useViewerQuery()
+
+  if (!data?.viewer?.isAdmin) return null
+
+  return (
+    <div className="flex items-center space-x-2">
+      <EditPhotographDialog
+        photograph={photograph}
+        trigger={<Button>Edit</Button>}
+      />
+    </div>
+  )
+}

--- a/src/components/Photographs/PhotographDetail.tsx
+++ b/src/components/Photographs/PhotographDetail.tsx
@@ -1,0 +1,115 @@
+import { format } from 'date-fns'
+import Image from 'next/image'
+import { NextSeo } from 'next-seo'
+import * as React from 'react'
+
+import { Detail } from '~/components/ListDetail/Detail'
+import { TitleBar } from '~/components/ListDetail/TitleBar'
+import { Tags } from '~/components/Tag'
+import routes from '~/config/routes'
+import { useGetPhotographQuery } from '~/graphql/types.generated'
+
+import { PhotographActions } from './PhotographActions'
+
+function formatCaptured(value: number | string | null | undefined) {
+  if (!value) return null
+  const d = new Date(value)
+  if (isNaN(d.getTime())) return null
+  return format(d, 'MMMM d, yyyy')
+}
+
+function MetaRow({ label, value }: { label: string; value: React.ReactNode }) {
+  if (!value) return null
+  return (
+    <div className="flex space-x-2 text-sm text-gray-1000 text-opacity-60 dark:text-white dark:text-opacity-40">
+      <dt className="font-medium">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  )
+}
+
+export function PhotographDetail({ slug }) {
+  const scrollContainerRef = React.useRef(null)
+  const titleRef = React.useRef(null)
+
+  const { data, loading, error } = useGetPhotographQuery({
+    variables: { slug },
+  })
+
+  if (loading) return <Detail.Loading />
+  if (!data?.photograph || error) return <Detail.Null />
+
+  const { photograph } = data
+  const cameraLens = [photograph.camera, photograph.lens]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <>
+      <NextSeo
+        title={photograph.title}
+        description={photograph.caption ?? routes.photographs.seo.description}
+        openGraph={{
+          title: photograph.title,
+          description: photograph.caption ?? routes.photographs.seo.description,
+          images: [
+            {
+              url: photograph.imageUrl,
+              alt: photograph.title,
+            },
+          ],
+        }}
+      />
+      <Detail.Container data-cy="photograph-detail" ref={scrollContainerRef}>
+        <TitleBar
+          backButton
+          globalMenu={false}
+          backButtonHref={'/photographs'}
+          magicTitle
+          title={photograph.title}
+          titleRef={titleRef}
+          scrollContainerRef={scrollContainerRef}
+          trailingAccessory={<PhotographActions photograph={photograph} />}
+        />
+
+        <Detail.ContentContainer>
+          <Detail.Header>
+            <div className="overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-900">
+              <Image
+                priority
+                src={photograph.imageUrl}
+                width={photograph.width}
+                height={photograph.height}
+                alt={photograph.title}
+                sizes="(max-width: 768px) 100vw, 768px"
+                className="h-auto w-full"
+              />
+            </div>
+
+            <div className="flex flex-col space-y-2">
+              <Detail.Title ref={titleRef}>{photograph.title}</Detail.Title>
+              {photograph.tags && photograph.tags.length > 0 && (
+                <Tags tags={photograph.tags} />
+              )}
+            </div>
+
+            {photograph.caption && (
+              <p className="text-primary text-base leading-relaxed">
+                {photograph.caption}
+              </p>
+            )}
+
+            <dl className="space-y-1">
+              <MetaRow
+                label="Captured"
+                value={formatCaptured(photograph.capturedAt)}
+              />
+              <MetaRow label="Location" value={photograph.location} />
+              <MetaRow label="Camera" value={cameraLens || null} />
+            </dl>
+          </Detail.Header>
+        </Detail.ContentContainer>
+      </Detail.Container>
+    </>
+  )
+}

--- a/src/components/Photographs/PhotographImageUploader.tsx
+++ b/src/components/Photographs/PhotographImageUploader.tsx
@@ -1,0 +1,131 @@
+import Image from 'next/image'
+import React, { useCallback, useState } from 'react'
+import { useDropzone } from 'react-dropzone'
+import { Trash, Upload } from 'react-feather'
+
+import { LoadingSpinner } from '~/components/LoadingSpinner'
+import { CLOUDFLARE_IMAGE_DELIVERY_BASE_URL } from '~/lib/cloudflare'
+
+interface UploadedImage {
+  url: string
+  width: number
+  height: number
+}
+
+interface Props {
+  initial?: UploadedImage | null
+  onImageUploaded: (image: UploadedImage | null) => void
+}
+
+function getImageDimensions(file: File): Promise<{
+  width: number
+  height: number
+}> {
+  return new Promise((resolve, reject) => {
+    const img = new window.Image()
+    const objectUrl = URL.createObjectURL(file)
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl)
+      resolve({ width: img.naturalWidth, height: img.naturalHeight })
+    }
+    img.onerror = (err) => {
+      URL.revokeObjectURL(objectUrl)
+      reject(err)
+    }
+    img.src = objectUrl
+  })
+}
+
+export function PhotographImageUploader({ initial, onImageUploaded }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [preview, setPreview] = useState<UploadedImage | null>(initial ?? null)
+
+  async function getSignedUrl() {
+    const data = await fetch('/api/images/sign').then((res) => res.json())
+    return data?.uploadURL
+  }
+
+  async function uploadFile({ file, signedUrl }) {
+    const data = new FormData()
+    data.append('file', file)
+    const upload = await fetch(signedUrl, {
+      method: 'POST',
+      body: data,
+    }).then((r) => r.json())
+    return upload?.result?.id
+  }
+
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    setLoading(true)
+    const file = acceptedFiles[0]
+
+    let dimensions: { width: number; height: number }
+    try {
+      dimensions = await getImageDimensions(file)
+    } catch (err) {
+      console.error({ err })
+      setLoading(false)
+      return
+    }
+
+    const signedUrl = await getSignedUrl()
+    if (!signedUrl) {
+      setLoading(false)
+      return console.error('No signed url')
+    }
+
+    const id = await uploadFile({ file, signedUrl })
+    if (!id) {
+      setLoading(false)
+      return console.error('Upload failed')
+    }
+
+    const url = `${CLOUDFLARE_IMAGE_DELIVERY_BASE_URL}/${id}/public`
+    const next = { url, width: dimensions.width, height: dimensions.height }
+    setLoading(false)
+    setPreview(next)
+    return onImageUploaded(next)
+  }, [])
+
+  const { getRootProps, getInputProps } = useDropzone({
+    onDrop,
+    maxSize: 10 * 1000 * 1000, // 10mb
+    accept: { 'image/jpeg': [], 'image/png': [], 'image/webp': [] },
+    multiple: false,
+  })
+
+  if (preview) {
+    return (
+      <div className="relative inline-block h-32 w-32 rounded-lg border border-gray-100 dark:border-gray-900">
+        <Image
+          src={preview.url}
+          width={128}
+          height={128}
+          alt="Photograph preview"
+          quality={100}
+          className="inline-block h-32 w-32 rounded-lg object-cover"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            setPreview(null)
+            onImageUploaded(null)
+          }}
+          className="absolute -top-3 -right-3 cursor-pointer rounded-full border-2 border-white bg-gray-1000 p-2 text-white shadow-md hover:bg-red-500 focus:bg-red-500 dark:border-gray-800 dark:bg-gray-700"
+        >
+          <Trash size={16} />
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      {...getRootProps()}
+      className="text-tertiary flex h-32 w-32 cursor-pointer items-center justify-center rounded-md border border-dashed border-gray-200 bg-gray-100 p-6 hover:bg-gray-150 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600 dark:hover:bg-gray-800"
+    >
+      <input {...getInputProps()} />
+      {loading ? <LoadingSpinner /> : <Upload size={16} />}
+    </div>
+  )
+}

--- a/src/components/Photographs/PhotographListItem.tsx
+++ b/src/components/Photographs/PhotographListItem.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import * as React from 'react'
+
+import { PhotographListItemFragment } from '~/graphql/types.generated'
+
+interface Props {
+  photograph: PhotographListItemFragment
+  active: boolean
+}
+
+export const PhotographListItem = React.memo<Props>(
+  ({ photograph, active }) => {
+    return (
+      <Link
+        href="/photographs/[slug]"
+        as={`/photographs/${photograph.slug}`}
+        className={`relative block aspect-square overflow-hidden rounded-xl ${
+          active
+            ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-white dark:ring-offset-gray-900'
+            : ''
+        }`}
+      >
+        <Image
+          src={photograph.imageUrl}
+          alt={photograph.title}
+          fill
+          sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+          className="object-cover"
+        />
+      </Link>
+    )
+  }
+)

--- a/src/components/Photographs/PhotographsList.tsx
+++ b/src/components/Photographs/PhotographsList.tsx
@@ -1,0 +1,72 @@
+import { useRouter } from 'next/router'
+import * as React from 'react'
+
+import { ListContainer } from '~/components/ListDetail/ListContainer'
+import { useGetPhotographsQuery } from '~/graphql/types.generated'
+
+import { ListLoadMore } from '../ListDetail/ListLoadMore'
+import { LoadingSpinner } from '../LoadingSpinner'
+import { PhotographListItem } from './PhotographListItem'
+import { PhotographsTitlebar } from './PhotographsTitlebar'
+
+export function PhotographsList() {
+  const router = useRouter()
+  const [isVisible, setIsVisible] = React.useState(false)
+  const [scrollContainerRef, setScrollContainerRef] = React.useState(null)
+
+  const { data, loading, fetchMore } = useGetPhotographsQuery()
+
+  function handleFetchMore() {
+    return fetchMore({
+      variables: {
+        after: data.photographs.pageInfo.endCursor,
+      },
+    })
+  }
+
+  React.useEffect(() => {
+    if (isVisible) handleFetchMore()
+  }, [isVisible])
+
+  if (loading && !data?.photographs) {
+    return (
+      <ListContainer onRef={setScrollContainerRef}>
+        <PhotographsTitlebar scrollContainerRef={scrollContainerRef} />
+        <div className="flex flex-1 items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      </ListContainer>
+    )
+  }
+
+  const edges = data?.photographs?.edges ?? []
+
+  return (
+    <ListContainer data-cy="photographs-list" onRef={setScrollContainerRef}>
+      <PhotographsTitlebar scrollContainerRef={scrollContainerRef} />
+
+      {edges.length === 0 ? (
+        <div className="p-6 text-sm text-gray-1000 text-opacity-40 dark:text-white dark:text-opacity-40">
+          No photographs yet.
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-1 p-3 md:grid-cols-3 lg:grid-cols-4">
+          {edges.map((edge) => {
+            const active = router.query.slug === edge.node.slug
+            return (
+              <PhotographListItem
+                key={edge.node.id}
+                photograph={edge.node}
+                active={active}
+              />
+            )
+          })}
+        </div>
+      )}
+
+      {data?.photographs?.pageInfo?.hasNextPage && (
+        <ListLoadMore setIsVisible={setIsVisible} />
+      )}
+    </ListContainer>
+  )
+}

--- a/src/components/Photographs/PhotographsTitlebar.tsx
+++ b/src/components/Photographs/PhotographsTitlebar.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { Plus } from 'react-feather'
+
+import { GhostButton } from '~/components/Button'
+import { TitleBar } from '~/components/ListDetail/TitleBar'
+import { useViewerQuery } from '~/graphql/types.generated'
+
+import { AddPhotographDialog } from './AddPhotographDialog'
+
+export function PhotographsTitlebar({ scrollContainerRef }) {
+  const { data } = useViewerQuery()
+
+  function trailingAccessory() {
+    if (data?.viewer?.isAdmin) {
+      return (
+        <AddPhotographDialog
+          trigger={
+            <GhostButton aria-label="Add Photograph" size="small-square">
+              <Plus size={16} />
+            </GhostButton>
+          }
+        />
+      )
+    }
+    return null
+  }
+
+  return (
+    <TitleBar
+      scrollContainerRef={scrollContainerRef}
+      title="Photographs"
+      trailingAccessory={trailingAccessory()}
+    />
+  )
+}

--- a/src/components/Sidebar/Navigation.tsx
+++ b/src/components/Sidebar/Navigation.tsx
@@ -13,6 +13,7 @@ import {
   GitHubIcon,
   HackerNewsIcon,
   HomeIcon,
+  PhotographsIcon,
   PodcastIcon,
   SecurityChecklistIcon,
   StackIcon,
@@ -20,6 +21,7 @@ import {
   TwitterIcon,
   WritingIcon,
 } from '~/components/Icon'
+import { AddPhotographDialog } from '~/components/Photographs/AddPhotographDialog'
 import { useViewerQuery } from '~/graphql/types.generated'
 
 import { NavigationLink } from './NavigationLink'
@@ -29,6 +31,18 @@ function ThisAddBookmarkDialog() {
     <AddBookmarkDialog
       trigger={
         <GhostButton aria-label="Add bookmark" size="small-square">
+          <Plus size={16} />
+        </GhostButton>
+      }
+    />
+  )
+}
+
+function ThisAddPhotographDialog() {
+  return (
+    <AddPhotographDialog
+      trigger={
+        <GhostButton aria-label="Add photograph" size="small-square">
           <Plus size={16} />
         </GhostButton>
       }
@@ -69,6 +83,16 @@ export function SidebarNavigation() {
       trailingAccessory: null,
       isActive: router.asPath.indexOf('/bookmarks') >= 0,
       trailingAction: data?.viewer?.isAdmin ? ThisAddBookmarkDialog : null,
+      isExternal: false,
+    },
+
+    {
+      href: '/photographs',
+      label: 'Photographs',
+      icon: PhotographsIcon,
+      trailingAccessory: null,
+      isActive: router.asPath.indexOf('/photographs') >= 0,
+      trailingAction: data?.viewer?.isAdmin ? ThisAddPhotographDialog : null,
       isExternal: false,
     },
 

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -84,6 +84,17 @@ const routes = {
       url: 'stack',
     }),
   },
+  // TODO: create OG image at /public/static/og/photographs.png
+  photographs: {
+    label: 'Photographs',
+    path: '/photographs',
+    seo: extendSEO({
+      title: 'Photographs',
+      description: 'A small collection of photographs.',
+      image: 'og/photographs.png',
+      url: 'photographs',
+    }),
+  },
   settings: {
     label: 'Settings',
     path: '/settings',

--- a/src/graphql/fragments/photograph.ts
+++ b/src/graphql/fragments/photograph.ts
@@ -1,0 +1,54 @@
+import { gql } from '@apollo/client'
+
+export const PhotographCoreFragment = gql`
+  fragment PhotographCore on Photograph {
+    __typename
+    id
+    slug
+    title
+    imageUrl
+    width
+    height
+  }
+`
+
+export const PhotographListItemFragment = gql`
+  fragment PhotographListItem on Photograph {
+    ...PhotographCore
+  }
+  ${PhotographCoreFragment}
+`
+
+export const PhotographDetailFragment = gql`
+  fragment PhotographDetail on Photograph {
+    ...PhotographCore
+    createdAt
+    publishedAt
+    caption
+    capturedAt
+    location
+    camera
+    lens
+    tags {
+      name
+    }
+  }
+  ${PhotographCoreFragment}
+`
+
+export const PhotographsConnectionFragment = gql`
+  fragment PhotographsConnection on PhotographsConnection {
+    pageInfo {
+      hasNextPage
+      totalCount
+      endCursor
+    }
+    edges {
+      cursor
+      node {
+        ...PhotographListItem
+      }
+    }
+  }
+  ${PhotographListItemFragment}
+`

--- a/src/graphql/mutations/photographs.ts
+++ b/src/graphql/mutations/photographs.ts
@@ -1,0 +1,27 @@
+import { gql } from '@apollo/client'
+
+import { PhotographDetailFragment } from '../fragments/photograph'
+
+export const ADD_PHOTOGRAPH = gql`
+  mutation addPhotograph($data: AddPhotographInput!) {
+    addPhotograph(data: $data) {
+      ...PhotographDetail
+    }
+  }
+  ${PhotographDetailFragment}
+`
+
+export const EDIT_PHOTOGRAPH = gql`
+  mutation editPhotograph($id: ID!, $data: EditPhotographInput!) {
+    editPhotograph(id: $id, data: $data) {
+      ...PhotographDetail
+    }
+  }
+  ${PhotographDetailFragment}
+`
+
+export const DELETE_PHOTOGRAPH = gql`
+  mutation deletePhotograph($id: ID!) {
+    deletePhotograph(id: $id)
+  }
+`

--- a/src/graphql/queries/photographs.ts
+++ b/src/graphql/queries/photographs.ts
@@ -1,0 +1,24 @@
+import { gql } from '@apollo/client'
+
+import {
+  PhotographDetailFragment,
+  PhotographsConnectionFragment,
+} from '../fragments/photograph'
+
+export const GET_PHOTOGRAPHS = gql`
+  query getPhotographs($first: Int, $after: String, $filter: PhotographFilter) {
+    photographs(first: $first, after: $after, filter: $filter) {
+      ...PhotographsConnection
+    }
+  }
+  ${PhotographsConnectionFragment}
+`
+
+export const GET_PHOTOGRAPH = gql`
+  query getPhotograph($slug: String!) {
+    photograph(slug: $slug) {
+      ...PhotographDetail
+    }
+  }
+  ${PhotographDetailFragment}
+`

--- a/src/graphql/resolvers/mutations/index.ts
+++ b/src/graphql/resolvers/mutations/index.ts
@@ -12,6 +12,11 @@ import {
 } from '~/graphql/resolvers/mutations/comment'
 import { editEmailSubscription } from '~/graphql/resolvers/mutations/emailSubscription'
 import {
+  addPhotograph,
+  deletePhotograph,
+  editPhotograph,
+} from '~/graphql/resolvers/mutations/photograph'
+import {
   addPost,
   deletePost,
   editPost,
@@ -38,6 +43,9 @@ export default {
   editStack: requiresAdmin(editStack),
   deleteStack: requiresAdmin(deleteStack),
   toggleStackUser: requiresUser(toggleStackUser),
+  addPhotograph: requiresAdmin(addPhotograph),
+  editPhotograph: requiresAdmin(editPhotograph),
+  deletePhotograph: requiresAdmin(deletePhotograph),
   addQuestion: requiresUser(addQuestion),
   editQuestion: requiresUser(editQuestion),
   deleteQuestion: requiresUser(deleteQuestion),

--- a/src/graphql/resolvers/mutations/photograph/index.tsx
+++ b/src/graphql/resolvers/mutations/photograph/index.tsx
@@ -1,0 +1,194 @@
+import fetch from 'isomorphic-unfetch'
+
+import { Context } from '~/graphql/context'
+import { UserInputError } from '~/graphql/helpers/errors'
+import {
+  MutationAddPhotographArgs,
+  MutationDeletePhotographArgs,
+  MutationEditPhotographArgs,
+} from '~/graphql/types.generated'
+import { graphcdn } from '~/lib/graphcdn'
+import { validUrl } from '~/lib/validators'
+
+async function deleteCloudflareImage(imageUrl: string) {
+  try {
+    const url = new URL(imageUrl)
+    if (!validUrl(url)) return
+    const [, , imageId] = url.pathname.split('/')
+    if (!imageId) return
+    await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}/images/v1/${imageId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${process.env.CLOUDFLARE_IMAGES_KEY}`,
+        },
+      }
+    )
+  } catch (err) {
+    console.error({ err })
+  }
+}
+
+export async function addPhotograph(
+  _,
+  args: MutationAddPhotographArgs,
+  ctx: Context
+) {
+  const { data } = args
+  const {
+    title,
+    slug,
+    caption,
+    imageUrl,
+    width,
+    height,
+    capturedAt,
+    location,
+    camera,
+    lens,
+    tag,
+  } = data
+  const { prisma } = ctx
+
+  if (!title || title.length === 0)
+    throw new UserInputError('Photograph must have a title')
+
+  if (!slug || slug.length === 0)
+    throw new UserInputError('Photograph must have a slug')
+
+  if (!imageUrl || imageUrl.length === 0)
+    throw new UserInputError('Photograph must have an image')
+
+  const tags = tag
+    ? {
+        connectOrCreate: {
+          where: { name: tag },
+          create: { name: tag },
+        },
+      }
+    : undefined
+
+  return await prisma.photograph
+    .create({
+      data: {
+        title,
+        slug,
+        caption: caption ?? null,
+        imageUrl,
+        width,
+        height,
+        capturedAt: capturedAt ?? null,
+        location: location ?? null,
+        camera: camera ?? null,
+        lens: lens ?? null,
+        publishedAt: new Date(),
+        tags,
+      },
+      include: { tags: true },
+    })
+    .then((photograph) => {
+      graphcdn.purgeList('photographs')
+      return photograph
+    })
+    .catch((err) => {
+      console.error({ err })
+      throw new UserInputError('Unable to add photograph')
+    })
+}
+
+export async function editPhotograph(
+  _,
+  args: MutationEditPhotographArgs,
+  ctx: Context
+) {
+  const { id, data } = args
+  const {
+    title,
+    slug,
+    caption,
+    capturedAt,
+    location,
+    camera,
+    lens,
+    tag,
+    published,
+  } = data
+  const { prisma } = ctx
+
+  if (!title || title.length === 0)
+    throw new UserInputError('Photograph must have a title')
+
+  if (!slug || slug.length === 0)
+    throw new UserInputError('Photograph must have a slug')
+
+  const existing = await prisma.photograph.findUnique({ where: { id } })
+  if (!existing) throw new UserInputError('Photograph not found')
+
+  await prisma.photograph.update({
+    where: { id },
+    data: { tags: { set: [] } },
+  })
+
+  const tags = tag
+    ? {
+        connectOrCreate: {
+          where: { name: tag },
+          create: { name: tag },
+        },
+      }
+    : undefined
+
+  let publishedAt: Date | null | undefined
+  if (published === true && !existing.publishedAt) publishedAt = new Date()
+  else if (published === false) publishedAt = null
+  else publishedAt = undefined
+
+  return await prisma.photograph
+    .update({
+      where: { id },
+      data: {
+        title,
+        slug,
+        caption: caption ?? null,
+        capturedAt: capturedAt ?? null,
+        location: location ?? null,
+        camera: camera ?? null,
+        lens: lens ?? null,
+        ...(publishedAt !== undefined ? { publishedAt } : {}),
+        tags,
+      },
+      include: { tags: true },
+    })
+    .then((photograph) => {
+      graphcdn.purgeList('photographs')
+      return photograph
+    })
+    .catch((err) => {
+      console.error({ err })
+      throw new UserInputError('Unable to edit photograph')
+    })
+}
+
+export async function deletePhotograph(
+  _,
+  args: MutationDeletePhotographArgs,
+  ctx: Context
+) {
+  const { id } = args
+  const { prisma } = ctx
+
+  const existing = await prisma.photograph.findUnique({ where: { id } })
+  if (existing?.imageUrl) await deleteCloudflareImage(existing.imageUrl)
+
+  return await prisma.photograph
+    .delete({ where: { id } })
+    .then(() => {
+      graphcdn.purgeList('photographs')
+      return true
+    })
+    .catch((err) => {
+      console.error({ err })
+      throw new UserInputError('Unable to delete photograph')
+    })
+}

--- a/src/graphql/resolvers/queries/index.ts
+++ b/src/graphql/resolvers/queries/index.ts
@@ -1,6 +1,7 @@
 import { getBookmark, getBookmarks } from './bookmarks'
 import { getComment, getComments } from './comment'
 import { getHackerNewsPost, getHackerNewsPosts } from './hackerNews'
+import { getPhotograph, getPhotographs } from './photograph'
 import { getPost, getPosts } from './posts'
 import { getQuestion, getQuestions } from './questions'
 import { getStack, getStacks } from './stack'
@@ -21,6 +22,8 @@ export default {
   comments: getComments,
   stacks: getStacks,
   stack: getStack,
+  photographs: getPhotographs,
+  photograph: getPhotograph,
   tags: getTags,
   hackerNewsPosts: getHackerNewsPosts,
   hackerNewsPost: getHackerNewsPost,

--- a/src/graphql/resolvers/queries/photograph/index.ts
+++ b/src/graphql/resolvers/queries/photograph/index.ts
@@ -1,0 +1,88 @@
+import { PAGINATION_AMOUNT } from '~/graphql/constants'
+import { Context } from '~/graphql/context'
+import {
+  GetPhotographQueryVariables,
+  GetPhotographsQueryVariables,
+} from '~/graphql/types.generated'
+
+export async function getPhotographs(
+  _,
+  args: GetPhotographsQueryVariables,
+  ctx: Context
+) {
+  const { first = PAGINATION_AMOUNT, after = undefined, filter = null } = args
+  const { prisma, viewer } = ctx
+
+  const skip = after ? 1 : 0
+  const cursor = after ? { id: after } : undefined
+  const take = first + 1
+
+  const where: any = {}
+  if (filter?.tag) {
+    where.tags = { some: { name: { equals: filter.tag } } }
+  }
+
+  // Non-admins can only see published photographs.
+  // Admins viewing with `published: false` see drafts; otherwise see all.
+  if (!viewer?.isAdmin) {
+    where.publishedAt = { not: null }
+  } else if (filter?.published === false) {
+    where.publishedAt = { equals: null }
+  }
+
+  try {
+    const edges = await prisma.photograph.findMany({
+      take,
+      skip,
+      cursor,
+      where,
+      orderBy: [{ capturedAt: 'desc' }, { createdAt: 'desc' }],
+      include: { tags: true },
+    })
+
+    const hasNextPage = edges.length > first
+    const trimmedEdges = hasNextPage ? edges.slice(0, -1) : edges
+    const edgesWithNodes = trimmedEdges.map((edge) => ({
+      cursor: edge.id,
+      node: edge,
+    }))
+
+    return {
+      pageInfo: {
+        hasNextPage,
+        totalCount: await prisma.photograph.count({ where }),
+        endCursor:
+          edgesWithNodes.length > 0
+            ? edgesWithNodes[edgesWithNodes.length - 1].cursor
+            : null,
+      },
+      edges: edgesWithNodes,
+    }
+  } catch (e) {
+    console.error({ error: e })
+    return {
+      pageInfo: { hasNextPage: false, totalCount: 0, endCursor: null },
+      edges: [],
+    }
+  }
+}
+
+export async function getPhotograph(
+  _,
+  { slug }: GetPhotographQueryVariables,
+  ctx: Context
+) {
+  const { prisma, viewer } = ctx
+
+  const photograph = await prisma.photograph
+    .findUnique({
+      where: { slug },
+      include: { tags: true },
+    })
+    .catch(() => null)
+
+  if (!photograph) return null
+  if (!photograph.publishedAt && !viewer?.isAdmin) return null
+
+  return photograph
+}

--- a/src/graphql/typeDefs/index.ts
+++ b/src/graphql/typeDefs/index.ts
@@ -81,6 +81,24 @@ export default gql`
     viewerHasReacted: Boolean
   }
 
+  type Photograph {
+    id: ID!
+    createdAt: Date!
+    updatedAt: Date
+    publishedAt: Date
+    slug: String!
+    title: String!
+    caption: String
+    imageUrl: String!
+    width: Int!
+    height: Int!
+    capturedAt: Date
+    location: String
+    camera: String
+    lens: String
+    tags: [Tag]!
+  }
+
   enum UserRole {
     BLOCKED
     USER
@@ -159,6 +177,11 @@ export default gql`
     published: Boolean
   }
 
+  input PhotographFilter {
+    tag: String
+    published: Boolean
+  }
+
   input QuestionFilter {
     status: QuestionStatus
   }
@@ -175,6 +198,11 @@ export default gql`
 
   type StackEdge {
     node: Stack
+    cursor: String
+  }
+
+  type PhotographEdge {
+    node: Photograph
     cursor: String
   }
 
@@ -199,6 +227,11 @@ export default gql`
     edges: [StackEdge]!
   }
 
+  type PhotographsConnection {
+    pageInfo: PageInfo
+    edges: [PhotographEdge]!
+  }
+
   type Query {
     viewer: User
     user(username: String!): User
@@ -210,6 +243,12 @@ export default gql`
     ): BookmarksConnection!
     stack(slug: String!): Stack
     stacks(first: Int, after: String): StacksConnection!
+    photograph(slug: String!): Photograph
+    photographs(
+      first: Int
+      after: String
+      filter: PhotographFilter
+    ): PhotographsConnection!
     comment(id: ID!): Comment
     comments(refId: ID!, type: CommentType!): [Comment]!
     posts(filter: WritingFilter): [Post]!
@@ -250,6 +289,32 @@ export default gql`
     image: String!
     description: String!
     tag: String
+  }
+
+  input AddPhotographInput {
+    title: String!
+    slug: String!
+    caption: String
+    imageUrl: String!
+    width: Int!
+    height: Int!
+    capturedAt: Date
+    location: String
+    camera: String
+    lens: String
+    tag: String
+  }
+
+  input EditPhotographInput {
+    title: String!
+    slug: String!
+    caption: String
+    capturedAt: Date
+    location: String
+    camera: String
+    lens: String
+    tag: String
+    published: Boolean
   }
 
   input AddBookmarkInput {
@@ -299,6 +364,9 @@ export default gql`
     editStack(id: ID!, data: EditStackInput!): Stack
     deleteStack(id: ID!): Boolean
     toggleStackUser(id: ID!): Stack
+    addPhotograph(data: AddPhotographInput!): Photograph
+    editPhotograph(id: ID!, data: EditPhotographInput!): Photograph
+    deletePhotograph(id: ID!): Boolean
     addQuestion(data: AddQuestionInput!): Question
     editQuestion(id: ID!, data: EditQuestionInput!): Question
     deleteQuestion(id: ID!): Boolean

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -42,6 +42,20 @@ export type AddBookmarkInput = {
   url: Scalars['String']['input']
 }
 
+export type AddPhotographInput = {
+  camera?: InputMaybe<Scalars['String']['input']>
+  caption?: InputMaybe<Scalars['String']['input']>
+  capturedAt?: InputMaybe<Scalars['Date']['input']>
+  height: Scalars['Int']['input']
+  imageUrl: Scalars['String']['input']
+  lens?: InputMaybe<Scalars['String']['input']>
+  location?: InputMaybe<Scalars['String']['input']>
+  slug: Scalars['String']['input']
+  tag?: InputMaybe<Scalars['String']['input']>
+  title: Scalars['String']['input']
+  width: Scalars['Int']['input']
+}
+
 export type AddPostInput = {
   excerpt?: InputMaybe<Scalars['String']['input']>
   slug: Scalars['String']['input']
@@ -120,6 +134,18 @@ export type EditBookmarkInput = {
   title: Scalars['String']['input']
 }
 
+export type EditPhotographInput = {
+  camera?: InputMaybe<Scalars['String']['input']>
+  caption?: InputMaybe<Scalars['String']['input']>
+  capturedAt?: InputMaybe<Scalars['Date']['input']>
+  lens?: InputMaybe<Scalars['String']['input']>
+  location?: InputMaybe<Scalars['String']['input']>
+  published?: InputMaybe<Scalars['Boolean']['input']>
+  slug: Scalars['String']['input']
+  tag?: InputMaybe<Scalars['String']['input']>
+  title: Scalars['String']['input']
+}
+
 export type EditPostInput = {
   excerpt?: InputMaybe<Scalars['String']['input']>
   published?: InputMaybe<Scalars['Boolean']['input']>
@@ -193,11 +219,13 @@ export type Mutation = {
   __typename?: 'Mutation'
   addBookmark?: Maybe<Bookmark>
   addComment?: Maybe<Comment>
+  addPhotograph?: Maybe<Photograph>
   addPost?: Maybe<Post>
   addQuestion?: Maybe<Question>
   addStack?: Maybe<Stack>
   deleteBookmark?: Maybe<Scalars['Boolean']['output']>
   deleteComment?: Maybe<Scalars['Boolean']['output']>
+  deletePhotograph?: Maybe<Scalars['Boolean']['output']>
   deletePost?: Maybe<Scalars['Boolean']['output']>
   deleteQuestion?: Maybe<Scalars['Boolean']['output']>
   deleteStack?: Maybe<Scalars['Boolean']['output']>
@@ -205,6 +233,7 @@ export type Mutation = {
   editBookmark?: Maybe<Bookmark>
   editComment?: Maybe<Comment>
   editEmailSubscription?: Maybe<User>
+  editPhotograph?: Maybe<Photograph>
   editPost?: Maybe<Post>
   editQuestion?: Maybe<Question>
   editStack?: Maybe<Stack>
@@ -221,6 +250,10 @@ export type MutationAddCommentArgs = {
   refId: Scalars['ID']['input']
   text: Scalars['String']['input']
   type: CommentType
+}
+
+export type MutationAddPhotographArgs = {
+  data: AddPhotographInput
 }
 
 export type MutationAddPostArgs = {
@@ -240,6 +273,10 @@ export type MutationDeleteBookmarkArgs = {
 }
 
 export type MutationDeleteCommentArgs = {
+  id: Scalars['ID']['input']
+}
+
+export type MutationDeletePhotographArgs = {
   id: Scalars['ID']['input']
 }
 
@@ -267,6 +304,11 @@ export type MutationEditCommentArgs = {
 
 export type MutationEditEmailSubscriptionArgs = {
   data?: InputMaybe<EmailSubscriptionInput>
+}
+
+export type MutationEditPhotographArgs = {
+  data: EditPhotographInput
+  id: Scalars['ID']['input']
 }
 
 export type MutationEditPostArgs = {
@@ -304,6 +346,42 @@ export type PageInfo = {
   totalCount?: Maybe<Scalars['Int']['output']>
 }
 
+export type Photograph = {
+  __typename?: 'Photograph'
+  camera?: Maybe<Scalars['String']['output']>
+  caption?: Maybe<Scalars['String']['output']>
+  capturedAt?: Maybe<Scalars['Date']['output']>
+  createdAt: Scalars['Date']['output']
+  height: Scalars['Int']['output']
+  id: Scalars['ID']['output']
+  imageUrl: Scalars['String']['output']
+  lens?: Maybe<Scalars['String']['output']>
+  location?: Maybe<Scalars['String']['output']>
+  publishedAt?: Maybe<Scalars['Date']['output']>
+  slug: Scalars['String']['output']
+  tags: Array<Maybe<Tag>>
+  title: Scalars['String']['output']
+  updatedAt?: Maybe<Scalars['Date']['output']>
+  width: Scalars['Int']['output']
+}
+
+export type PhotographEdge = {
+  __typename?: 'PhotographEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node?: Maybe<Photograph>
+}
+
+export type PhotographFilter = {
+  published?: InputMaybe<Scalars['Boolean']['input']>
+  tag?: InputMaybe<Scalars['String']['input']>
+}
+
+export type PhotographsConnection = {
+  __typename?: 'PhotographsConnection'
+  edges: Array<Maybe<PhotographEdge>>
+  pageInfo?: Maybe<PageInfo>
+}
+
 export type Post = {
   __typename?: 'Post'
   author?: Maybe<User>
@@ -328,6 +406,8 @@ export type Query = {
   comments: Array<Maybe<Comment>>
   hackerNewsPost?: Maybe<HackerNewsPost>
   hackerNewsPosts: Array<Maybe<HackerNewsPost>>
+  photograph?: Maybe<Photograph>
+  photographs: PhotographsConnection
   post?: Maybe<Post>
   posts: Array<Maybe<Post>>
   question?: Maybe<Question>
@@ -360,6 +440,16 @@ export type QueryCommentsArgs = {
 
 export type QueryHackerNewsPostArgs = {
   id: Scalars['ID']['input']
+}
+
+export type QueryPhotographArgs = {
+  slug: Scalars['String']['input']
+}
+
+export type QueryPhotographsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<PhotographFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type QueryPostArgs = {
@@ -638,6 +728,67 @@ export type HackerNewsPostInfoFragment = {
       } | null> | null
     } | null> | null
   } | null> | null
+}
+
+export type PhotographCoreFragment = {
+  __typename: 'Photograph'
+  id: string
+  slug: string
+  title: string
+  imageUrl: string
+  width: number
+  height: number
+}
+
+export type PhotographListItemFragment = {
+  __typename: 'Photograph'
+  id: string
+  slug: string
+  title: string
+  imageUrl: string
+  width: number
+  height: number
+}
+
+export type PhotographDetailFragment = {
+  __typename: 'Photograph'
+  createdAt: any
+  publishedAt?: any | null
+  caption?: string | null
+  capturedAt?: any | null
+  location?: string | null
+  camera?: string | null
+  lens?: string | null
+  id: string
+  slug: string
+  title: string
+  imageUrl: string
+  width: number
+  height: number
+  tags: Array<{ __typename?: 'Tag'; name: string } | null>
+}
+
+export type PhotographsConnectionFragment = {
+  __typename?: 'PhotographsConnection'
+  pageInfo?: {
+    __typename?: 'PageInfo'
+    hasNextPage?: boolean | null
+    totalCount?: number | null
+    endCursor?: string | null
+  } | null
+  edges: Array<{
+    __typename?: 'PhotographEdge'
+    cursor?: string | null
+    node?: {
+      __typename: 'Photograph'
+      id: string
+      slug: string
+      title: string
+      imageUrl: string
+      width: number
+      height: number
+    } | null
+  } | null>
 }
 
 export type PostCoreFragment = {
@@ -975,6 +1126,66 @@ export type EditEmailSubscriptionMutation = {
       type?: EmailSubscriptionType | null
     } | null> | null
   } | null
+}
+
+export type AddPhotographMutationVariables = Exact<{
+  data: AddPhotographInput
+}>
+
+export type AddPhotographMutation = {
+  __typename?: 'Mutation'
+  addPhotograph?: {
+    __typename: 'Photograph'
+    createdAt: any
+    publishedAt?: any | null
+    caption?: string | null
+    capturedAt?: any | null
+    location?: string | null
+    camera?: string | null
+    lens?: string | null
+    id: string
+    slug: string
+    title: string
+    imageUrl: string
+    width: number
+    height: number
+    tags: Array<{ __typename?: 'Tag'; name: string } | null>
+  } | null
+}
+
+export type EditPhotographMutationVariables = Exact<{
+  id: Scalars['ID']['input']
+  data: EditPhotographInput
+}>
+
+export type EditPhotographMutation = {
+  __typename?: 'Mutation'
+  editPhotograph?: {
+    __typename: 'Photograph'
+    createdAt: any
+    publishedAt?: any | null
+    caption?: string | null
+    capturedAt?: any | null
+    location?: string | null
+    camera?: string | null
+    lens?: string | null
+    id: string
+    slug: string
+    title: string
+    imageUrl: string
+    width: number
+    height: number
+    tags: Array<{ __typename?: 'Tag'; name: string } | null>
+  } | null
+}
+
+export type DeletePhotographMutationVariables = Exact<{
+  id: Scalars['ID']['input']
+}>
+
+export type DeletePhotographMutation = {
+  __typename?: 'Mutation'
+  deletePhotograph?: boolean | null
 }
 
 export type EditPostMutationVariables = Exact<{
@@ -1407,6 +1618,63 @@ export type GetHackerNewsPostQuery = {
   } | null
 }
 
+export type GetPhotographsQueryVariables = Exact<{
+  first?: InputMaybe<Scalars['Int']['input']>
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<PhotographFilter>
+}>
+
+export type GetPhotographsQuery = {
+  __typename?: 'Query'
+  photographs: {
+    __typename?: 'PhotographsConnection'
+    pageInfo?: {
+      __typename?: 'PageInfo'
+      hasNextPage?: boolean | null
+      totalCount?: number | null
+      endCursor?: string | null
+    } | null
+    edges: Array<{
+      __typename?: 'PhotographEdge'
+      cursor?: string | null
+      node?: {
+        __typename: 'Photograph'
+        id: string
+        slug: string
+        title: string
+        imageUrl: string
+        width: number
+        height: number
+      } | null
+    } | null>
+  }
+}
+
+export type GetPhotographQueryVariables = Exact<{
+  slug: Scalars['String']['input']
+}>
+
+export type GetPhotographQuery = {
+  __typename?: 'Query'
+  photograph?: {
+    __typename: 'Photograph'
+    createdAt: any
+    publishedAt?: any | null
+    caption?: string | null
+    capturedAt?: any | null
+    location?: string | null
+    camera?: string | null
+    lens?: string | null
+    id: string
+    slug: string
+    title: string
+    imageUrl: string
+    width: number
+    height: number
+    tags: Array<{ __typename?: 'Tag'; name: string } | null>
+  } | null
+}
+
 export type GetPostsQueryVariables = Exact<{
   filter?: InputMaybe<WritingFilter>
 }>
@@ -1754,6 +2022,55 @@ export const HackerNewsPostInfoFragmentDoc = gql`
   }
   ${HackerNewsListItemInfoFragmentDoc}
   ${HackerNewsCommentInfoFragmentDoc}
+`
+export const PhotographCoreFragmentDoc = gql`
+  fragment PhotographCore on Photograph {
+    __typename
+    id
+    slug
+    title
+    imageUrl
+    width
+    height
+  }
+`
+export const PhotographDetailFragmentDoc = gql`
+  fragment PhotographDetail on Photograph {
+    ...PhotographCore
+    createdAt
+    publishedAt
+    caption
+    capturedAt
+    location
+    camera
+    lens
+    tags {
+      name
+    }
+  }
+  ${PhotographCoreFragmentDoc}
+`
+export const PhotographListItemFragmentDoc = gql`
+  fragment PhotographListItem on Photograph {
+    ...PhotographCore
+  }
+  ${PhotographCoreFragmentDoc}
+`
+export const PhotographsConnectionFragmentDoc = gql`
+  fragment PhotographsConnection on PhotographsConnection {
+    pageInfo {
+      hasNextPage
+      totalCount
+      endCursor
+    }
+    edges {
+      cursor
+      node {
+        ...PhotographListItem
+      }
+    }
+  }
+  ${PhotographListItemFragmentDoc}
 `
 export const PostCoreFragmentDoc = gql`
   fragment PostCore on Post {
@@ -2247,6 +2564,160 @@ export type EditEmailSubscriptionMutationOptions =
   ApolloReactCommon.BaseMutationOptions<
     EditEmailSubscriptionMutation,
     EditEmailSubscriptionMutationVariables
+  >
+export const AddPhotographDocument = gql`
+  mutation addPhotograph($data: AddPhotographInput!) {
+    addPhotograph(data: $data) {
+      ...PhotographDetail
+    }
+  }
+  ${PhotographDetailFragmentDoc}
+`
+export type AddPhotographMutationFn = ApolloReactCommon.MutationFunction<
+  AddPhotographMutation,
+  AddPhotographMutationVariables
+>
+
+/**
+ * __useAddPhotographMutation__
+ *
+ * To run a mutation, you first call `useAddPhotographMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddPhotographMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addPhotographMutation, { data, loading, error }] = useAddPhotographMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useAddPhotographMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    AddPhotographMutation,
+    AddPhotographMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useMutation<
+    AddPhotographMutation,
+    AddPhotographMutationVariables
+  >(AddPhotographDocument, options)
+}
+export type AddPhotographMutationHookResult = ReturnType<
+  typeof useAddPhotographMutation
+>
+export type AddPhotographMutationResult =
+  ApolloReactCommon.MutationResult<AddPhotographMutation>
+export type AddPhotographMutationOptions =
+  ApolloReactCommon.BaseMutationOptions<
+    AddPhotographMutation,
+    AddPhotographMutationVariables
+  >
+export const EditPhotographDocument = gql`
+  mutation editPhotograph($id: ID!, $data: EditPhotographInput!) {
+    editPhotograph(id: $id, data: $data) {
+      ...PhotographDetail
+    }
+  }
+  ${PhotographDetailFragmentDoc}
+`
+export type EditPhotographMutationFn = ApolloReactCommon.MutationFunction<
+  EditPhotographMutation,
+  EditPhotographMutationVariables
+>
+
+/**
+ * __useEditPhotographMutation__
+ *
+ * To run a mutation, you first call `useEditPhotographMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditPhotographMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [editPhotographMutation, { data, loading, error }] = useEditPhotographMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useEditPhotographMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    EditPhotographMutation,
+    EditPhotographMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useMutation<
+    EditPhotographMutation,
+    EditPhotographMutationVariables
+  >(EditPhotographDocument, options)
+}
+export type EditPhotographMutationHookResult = ReturnType<
+  typeof useEditPhotographMutation
+>
+export type EditPhotographMutationResult =
+  ApolloReactCommon.MutationResult<EditPhotographMutation>
+export type EditPhotographMutationOptions =
+  ApolloReactCommon.BaseMutationOptions<
+    EditPhotographMutation,
+    EditPhotographMutationVariables
+  >
+export const DeletePhotographDocument = gql`
+  mutation deletePhotograph($id: ID!) {
+    deletePhotograph(id: $id)
+  }
+`
+export type DeletePhotographMutationFn = ApolloReactCommon.MutationFunction<
+  DeletePhotographMutation,
+  DeletePhotographMutationVariables
+>
+
+/**
+ * __useDeletePhotographMutation__
+ *
+ * To run a mutation, you first call `useDeletePhotographMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeletePhotographMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deletePhotographMutation, { data, loading, error }] = useDeletePhotographMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useDeletePhotographMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    DeletePhotographMutation,
+    DeletePhotographMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useMutation<
+    DeletePhotographMutation,
+    DeletePhotographMutationVariables
+  >(DeletePhotographDocument, options)
+}
+export type DeletePhotographMutationHookResult = ReturnType<
+  typeof useDeletePhotographMutation
+>
+export type DeletePhotographMutationResult =
+  ApolloReactCommon.MutationResult<DeletePhotographMutation>
+export type DeletePhotographMutationOptions =
+  ApolloReactCommon.BaseMutationOptions<
+    DeletePhotographMutation,
+    DeletePhotographMutationVariables
   >
 export const EditPostDocument = gql`
   mutation editPost($id: ID!, $data: EditPostInput!) {
@@ -3429,6 +3900,212 @@ export type GetHackerNewsPostSuspenseQueryHookResult = ReturnType<
 export type GetHackerNewsPostQueryResult = ApolloReactCommon.QueryResult<
   GetHackerNewsPostQuery,
   GetHackerNewsPostQueryVariables
+>
+export const GetPhotographsDocument = gql`
+  query getPhotographs($first: Int, $after: String, $filter: PhotographFilter) {
+    photographs(first: $first, after: $after, filter: $filter) {
+      ...PhotographsConnection
+    }
+  }
+  ${PhotographsConnectionFragmentDoc}
+`
+
+/**
+ * __useGetPhotographsQuery__
+ *
+ * To run a query within a React component, call `useGetPhotographsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPhotographsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPhotographsQuery({
+ *   variables: {
+ *      first: // value for 'first'
+ *      after: // value for 'after'
+ *      filter: // value for 'filter'
+ *   },
+ * });
+ */
+export function useGetPhotographsQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetPhotographsQuery,
+    GetPhotographsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useQuery<
+    GetPhotographsQuery,
+    GetPhotographsQueryVariables
+  >(GetPhotographsDocument, options)
+}
+export function useGetPhotographsLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetPhotographsQuery,
+    GetPhotographsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useLazyQuery<
+    GetPhotographsQuery,
+    GetPhotographsQueryVariables
+  >(GetPhotographsDocument, options)
+}
+// @ts-ignore
+export function useGetPhotographsSuspenseQuery(
+  baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<
+    GetPhotographsQuery,
+    GetPhotographsQueryVariables
+  >
+): ApolloReactHooks.UseSuspenseQueryResult<
+  GetPhotographsQuery,
+  GetPhotographsQueryVariables
+>
+export function useGetPhotographsSuspenseQuery(
+  baseOptions?:
+    | ApolloReactHooks.SkipToken
+    | ApolloReactHooks.SuspenseQueryHookOptions<
+        GetPhotographsQuery,
+        GetPhotographsQueryVariables
+      >
+): ApolloReactHooks.UseSuspenseQueryResult<
+  GetPhotographsQuery | undefined,
+  GetPhotographsQueryVariables
+>
+export function useGetPhotographsSuspenseQuery(
+  baseOptions?:
+    | ApolloReactHooks.SkipToken
+    | ApolloReactHooks.SuspenseQueryHookOptions<
+        GetPhotographsQuery,
+        GetPhotographsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === ApolloReactHooks.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useSuspenseQuery<
+    GetPhotographsQuery,
+    GetPhotographsQueryVariables
+  >(GetPhotographsDocument, options)
+}
+export type GetPhotographsQueryHookResult = ReturnType<
+  typeof useGetPhotographsQuery
+>
+export type GetPhotographsLazyQueryHookResult = ReturnType<
+  typeof useGetPhotographsLazyQuery
+>
+export type GetPhotographsSuspenseQueryHookResult = ReturnType<
+  typeof useGetPhotographsSuspenseQuery
+>
+export type GetPhotographsQueryResult = ApolloReactCommon.QueryResult<
+  GetPhotographsQuery,
+  GetPhotographsQueryVariables
+>
+export const GetPhotographDocument = gql`
+  query getPhotograph($slug: String!) {
+    photograph(slug: $slug) {
+      ...PhotographDetail
+    }
+  }
+  ${PhotographDetailFragmentDoc}
+`
+
+/**
+ * __useGetPhotographQuery__
+ *
+ * To run a query within a React component, call `useGetPhotographQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPhotographQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPhotographQuery({
+ *   variables: {
+ *      slug: // value for 'slug'
+ *   },
+ * });
+ */
+export function useGetPhotographQuery(
+  baseOptions: ApolloReactHooks.QueryHookOptions<
+    GetPhotographQuery,
+    GetPhotographQueryVariables
+  > &
+    (
+      | { variables: GetPhotographQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useQuery<
+    GetPhotographQuery,
+    GetPhotographQueryVariables
+  >(GetPhotographDocument, options)
+}
+export function useGetPhotographLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetPhotographQuery,
+    GetPhotographQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useLazyQuery<
+    GetPhotographQuery,
+    GetPhotographQueryVariables
+  >(GetPhotographDocument, options)
+}
+// @ts-ignore
+export function useGetPhotographSuspenseQuery(
+  baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<
+    GetPhotographQuery,
+    GetPhotographQueryVariables
+  >
+): ApolloReactHooks.UseSuspenseQueryResult<
+  GetPhotographQuery,
+  GetPhotographQueryVariables
+>
+export function useGetPhotographSuspenseQuery(
+  baseOptions?:
+    | ApolloReactHooks.SkipToken
+    | ApolloReactHooks.SuspenseQueryHookOptions<
+        GetPhotographQuery,
+        GetPhotographQueryVariables
+      >
+): ApolloReactHooks.UseSuspenseQueryResult<
+  GetPhotographQuery | undefined,
+  GetPhotographQueryVariables
+>
+export function useGetPhotographSuspenseQuery(
+  baseOptions?:
+    | ApolloReactHooks.SkipToken
+    | ApolloReactHooks.SuspenseQueryHookOptions<
+        GetPhotographQuery,
+        GetPhotographQueryVariables
+      >
+) {
+  const options =
+    baseOptions === ApolloReactHooks.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions }
+  return ApolloReactHooks.useSuspenseQuery<
+    GetPhotographQuery,
+    GetPhotographQueryVariables
+  >(GetPhotographDocument, options)
+}
+export type GetPhotographQueryHookResult = ReturnType<
+  typeof useGetPhotographQuery
+>
+export type GetPhotographLazyQueryHookResult = ReturnType<
+  typeof useGetPhotographLazyQuery
+>
+export type GetPhotographSuspenseQueryHookResult = ReturnType<
+  typeof useGetPhotographSuspenseQuery
+>
+export type GetPhotographQueryResult = ApolloReactCommon.QueryResult<
+  GetPhotographQuery,
+  GetPhotographQueryVariables
 >
 export const GetPostsDocument = gql`
   query getPosts($filter: WritingFilter) {

--- a/src/lib/apollo/index.ts
+++ b/src/lib/apollo/index.ts
@@ -59,6 +59,7 @@ export function createApolloClient({ initialState = {}, context = {} }) {
           bookmarks: relayStylePagination(['filter']),
           questions: relayStylePagination(['filter']),
           stacks: relayStylePagination(),
+          photographs: relayStylePagination(['filter']),
         },
       },
       Comments: {

--- a/src/pages/photographs/[slug].tsx
+++ b/src/pages/photographs/[slug].tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+
+import { ListDetailView, SiteLayout } from '~/components/Layouts'
+import { PhotographDetail } from '~/components/Photographs/PhotographDetail'
+import { PhotographsList } from '~/components/Photographs/PhotographsList'
+import { withProviders } from '~/components/Providers/withProviders'
+import { getContext } from '~/graphql/context'
+import { GET_PHOTOGRAPH, GET_PHOTOGRAPHS } from '~/graphql/queries/photographs'
+import { GET_VIEWER } from '~/graphql/queries/viewer'
+import { addApolloState, initApolloClient } from '~/lib/apollo'
+
+function PhotographDetailPage({ slug }) {
+  return <PhotographDetail slug={slug} />
+}
+
+export async function getServerSideProps({ params: { slug }, req, res }) {
+  const context = await getContext(req, res)
+  const apolloClient = initApolloClient({ context })
+
+  const { data } = await apolloClient.query({
+    query: GET_PHOTOGRAPH,
+    variables: { slug },
+  })
+
+  if (!data?.photograph) {
+    return { notFound: true }
+  }
+
+  await Promise.all([
+    apolloClient.query({ query: GET_VIEWER }),
+    apolloClient.query({ query: GET_PHOTOGRAPHS }),
+  ])
+
+  return addApolloState(apolloClient, {
+    props: { slug },
+  })
+}
+
+PhotographDetailPage.getLayout = withProviders(function getLayout(page) {
+  return (
+    <SiteLayout>
+      <ListDetailView list={<PhotographsList />} hasDetail detail={page} />
+    </SiteLayout>
+  )
+})
+
+export default PhotographDetailPage

--- a/src/pages/photographs/index.tsx
+++ b/src/pages/photographs/index.tsx
@@ -1,0 +1,51 @@
+import { NextSeo } from 'next-seo'
+import * as React from 'react'
+
+import { ListDetailView, SiteLayout } from '~/components/Layouts'
+import { PhotographsList } from '~/components/Photographs/PhotographsList'
+import { withProviders } from '~/components/Providers/withProviders'
+import routes from '~/config/routes'
+import { getContext } from '~/graphql/context'
+import { GET_PHOTOGRAPHS } from '~/graphql/queries/photographs'
+import { GET_VIEWER } from '~/graphql/queries/viewer'
+import { addApolloState, initApolloClient } from '~/lib/apollo'
+
+function PhotographsPage() {
+  return (
+    <>
+      <NextSeo
+        title={routes.photographs.seo.title}
+        description={routes.photographs.seo.description}
+        openGraph={routes.photographs.seo.openGraph}
+      />
+    </>
+  )
+}
+
+PhotographsPage.getLayout = withProviders(function getLayout(page) {
+  return (
+    <SiteLayout>
+      <ListDetailView
+        list={<PhotographsList />}
+        hasDetail={false}
+        detail={page}
+      />
+    </SiteLayout>
+  )
+})
+
+export async function getServerSideProps({ req, res }) {
+  const context = await getContext(req, res)
+  const apolloClient = initApolloClient({ context })
+
+  await Promise.all([
+    apolloClient.query({ query: GET_VIEWER }),
+    apolloClient.query({ query: GET_PHOTOGRAPHS }),
+  ])
+
+  return addApolloState(apolloClient, {
+    props: {},
+  })
+}
+
+export default PhotographsPage


### PR DESCRIPTION
Adds a new /photographs section mirroring the Stack pattern: list/detail layout with a 2/3/4-col grid of square thumbnails, full-bleed detail with caption + capture metadata, admin-only Add/Edit/Delete via Cloudflare Images. Includes Prisma model, Photograph GraphQL type/queries/mutations guarded by requiresAdmin, sidebar nav entry with admin add-shortcut, and Apollo relayStylePagination wiring.