### PR TITLE
fix(auth): forward session cookie to apollo SSR client

### DIFF
--- a/src/lib/apollo/index.ts
+++ b/src/lib/apollo/index.ts
@@ -17,12 +17,11 @@ import { APOLLO_STATE_PROP_NAME, GRAPHQL_ENDPOINT } from '~/graphql/constants'
 
 let apolloClient
 
-function createLink() {
-  // Use HttpLink for both client and server side
-  // This simplifies the setup and removes dependency on deprecated @apollo/link-schema
+function createLink(headers: Record<string, string> = {}) {
   return new HttpLink({
     uri: GRAPHQL_ENDPOINT || '/api/graphql',
     credentials: 'include',
+    headers,
   })
 }
 
@@ -49,8 +48,14 @@ const errorLink = new ErrorLink(({ error }) => {
   }
 })
 
-export function createApolloClient({ initialState = {}, context = {} }) {
-  const link = ApolloLink.from([errorLink, createLink()])
+export function createApolloClient({
+  initialState = {},
+  headers = {},
+}: {
+  initialState?: any
+  headers?: Record<string, string>
+}) {
+  const link = ApolloLink.from([errorLink, createLink(headers)])
   const ssrMode = typeof window === 'undefined'
   const cache = new InMemoryCache({
     typePolicies: {
@@ -92,9 +97,15 @@ export function createApolloClient({ initialState = {}, context = {} }) {
   })
 }
 
-export function initApolloClient({ initialState = null, context = {} }) {
+export function initApolloClient({
+  initialState = null,
+  headers = {},
+}: {
+  initialState?: any
+  headers?: Record<string, string>
+}) {
   const _apolloClient =
-    apolloClient ?? createApolloClient({ initialState, context })
+    apolloClient ?? createApolloClient({ initialState, headers })
 
   // If your page has Next.js data fetching methods that use Apollo Client, the initial state
   // gets hydrated here

--- a/src/pages/ama/[id].tsx
+++ b/src/pages/ama/[id].tsx
@@ -4,7 +4,6 @@ import { QuestionDetail } from '~/components/AMA/QuestionDetail'
 import { QuestionsList } from '~/components/AMA/QuestionsList'
 import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
-import { getContext } from '~/graphql/context'
 import { GET_COMMENTS } from '~/graphql/queries/comments'
 import { GET_QUESTION, GET_QUESTIONS } from '~/graphql/queries/questions'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
@@ -16,8 +15,9 @@ function QuestionDetailPage({ id }) {
 }
 
 export async function getServerSideProps({ params: { id }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({

--- a/src/pages/ama/index.tsx
+++ b/src/pages/ama/index.tsx
@@ -5,7 +5,6 @@ import { QuestionsList } from '~/components/AMA/QuestionsList'
 import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
 import routes from '~/config/routes'
-import { getContext } from '~/graphql/context'
 import { GET_QUESTIONS } from '~/graphql/queries/questions'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
 import { QuestionStatus } from '~/graphql/types.generated'
@@ -22,8 +21,9 @@ function AmaPage() {
 }
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/bookmarks/[id].tsx
+++ b/src/pages/bookmarks/[id].tsx
@@ -4,7 +4,6 @@ import { BookmarkDetail } from '~/components/Bookmarks/BookmarkDetail'
 import { BookmarksList } from '~/components/Bookmarks/BookmarksList'
 import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
-import { getContext } from '~/graphql/context'
 import { GET_BOOKMARKS } from '~/graphql/queries/bookmarks'
 import { GET_BOOKMARK } from '~/graphql/queries/bookmarks'
 import { GET_COMMENTS } from '~/graphql/queries/comments'
@@ -18,8 +17,9 @@ function BookmarkPage({ id }) {
 }
 
 export async function getServerSideProps({ params: { id }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/bookmarks/index.tsx
+++ b/src/pages/bookmarks/index.tsx
@@ -5,7 +5,6 @@ import { BookmarksList } from '~/components/Bookmarks/BookmarksList'
 import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
 import routes from '~/config/routes'
-import { getContext } from '~/graphql/context'
 import { GET_BOOKMARKS } from '~/graphql/queries/bookmarks'
 import { GET_TAGS } from '~/graphql/queries/tags'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
@@ -22,8 +21,9 @@ function BookmarksPage() {
 }
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/hn/[id].tsx
+++ b/src/pages/hn/[id].tsx
@@ -6,7 +6,6 @@ import { PostsList } from '~/components/HackerNews/PostsList'
 import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { Detail } from '~/components/ListDetail/Detail'
 import { withProviders } from '~/components/Providers/withProviders'
-import { getContext } from '~/graphql/context'
 import {
   GET_HACKER_NEWS_POST,
   GET_HACKER_NEWS_POSTS,
@@ -24,8 +23,9 @@ function HNPostPage({ id }) {
 }
 
 export async function getServerSideProps({ params: { id }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({

--- a/src/pages/hn/index.tsx
+++ b/src/pages/hn/index.tsx
@@ -5,7 +5,6 @@ import { PostsList } from '~/components/HackerNews/PostsList'
 import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
 import routes from '~/config/routes'
-import { getContext } from '~/graphql/context'
 import { GET_HACKER_NEWS_POSTS } from '~/graphql/queries/hackerNews'
 import { addApolloState, initApolloClient } from '~/lib/apollo'
 
@@ -20,8 +19,9 @@ function HNPage() {
 }
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await apolloClient.query({
     query: GET_HACKER_NEWS_POSTS,

--- a/src/pages/photographs/[slug].tsx
+++ b/src/pages/photographs/[slug].tsx
@@ -4,7 +4,6 @@ import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { PhotographDetail } from '~/components/Photographs/PhotographDetail'
 import { PhotographsList } from '~/components/Photographs/PhotographsList'
 import { withProviders } from '~/components/Providers/withProviders'
-import { getContext } from '~/graphql/context'
 import { GET_PHOTOGRAPH, GET_PHOTOGRAPHS } from '~/graphql/queries/photographs'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
 import { addApolloState, initApolloClient } from '~/lib/apollo'
@@ -14,8 +13,9 @@ function PhotographDetailPage({ slug }) {
 }
 
 export async function getServerSideProps({ params: { slug }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   const { data } = await apolloClient.query({
     query: GET_PHOTOGRAPH,

--- a/src/pages/photographs/index.tsx
+++ b/src/pages/photographs/index.tsx
@@ -5,7 +5,6 @@ import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { PhotographsList } from '~/components/Photographs/PhotographsList'
 import { withProviders } from '~/components/Providers/withProviders'
 import routes from '~/config/routes'
-import { getContext } from '~/graphql/context'
 import { GET_PHOTOGRAPHS } from '~/graphql/queries/photographs'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
 import { addApolloState, initApolloClient } from '~/lib/apollo'
@@ -35,8 +34,9 @@ PhotographsPage.getLayout = withProviders(function getLayout(page) {
 })
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/stack/[slug].tsx
+++ b/src/pages/stack/[slug].tsx
@@ -4,7 +4,6 @@ import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
 import { StackDetail } from '~/components/Stack/StackDetail'
 import { StackList } from '~/components/Stack/StackList'
-import { getContext } from '~/graphql/context'
 import { GET_COMMENTS } from '~/graphql/queries/comments'
 import { GET_STACK, GET_STACKS } from '~/graphql/queries/stack'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
@@ -16,8 +15,9 @@ function StackDetailPage({ slug }) {
 }
 
 export async function getServerSideProps({ params: { slug }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   const { data } = await apolloClient.query({
     query: GET_STACK,

--- a/src/pages/stack/index.tsx
+++ b/src/pages/stack/index.tsx
@@ -5,7 +5,6 @@ import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
 import { StackList } from '~/components/Stack/StackList'
 import routes from '~/config/routes'
-import { getContext } from '~/graphql/context'
 import { GET_STACKS } from '~/graphql/queries/stack'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
 import { addApolloState, initApolloClient } from '~/lib/apollo'
@@ -31,8 +30,9 @@ StackPage.getLayout = withProviders(function getLayout(page) {
 })
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/u/[username].tsx
+++ b/src/pages/u/[username].tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 
 import { ListDetailView } from '~/components/Layouts'
 import { UserDetail } from '~/components/UserProfile/UserDetail'
-import { getContext } from '~/graphql/context'
 import { GET_USER } from '~/graphql/queries/user'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
 import { addApolloState, initApolloClient } from '~/lib/apollo'
@@ -18,8 +17,9 @@ export default function UserPage({ username }) {
 }
 
 export async function getServerSideProps({ params: { username }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/writing/[slug]/edit.tsx
+++ b/src/pages/writing/[slug]/edit.tsx
@@ -4,7 +4,6 @@ import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { Detail } from '~/components/ListDetail/Detail'
 import { withProviders } from '~/components/Providers/withProviders'
 import { PostEditor } from '~/components/Writing/Editor/PostEditor'
-import { getContext } from '~/graphql/context'
 import { GET_POST } from '~/graphql/queries/posts'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
 import { useViewerQuery } from '~/graphql/types.generated'
@@ -17,8 +16,9 @@ function EditPostPage({ slug }) {
 }
 
 export async function getServerSideProps({ params: { slug }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/writing/[slug]/index.tsx
+++ b/src/pages/writing/[slug]/index.tsx
@@ -5,7 +5,6 @@ import { withProviders } from '~/components/Providers/withProviders'
 import { PostEditor } from '~/components/Writing/Editor/PostEditor'
 import { PostDetail } from '~/components/Writing/PostDetail'
 import { PostsList } from '~/components/Writing/PostsList'
-import { getContext } from '~/graphql/context'
 import { GET_COMMENTS } from '~/graphql/queries/comments'
 import { GET_POST, GET_POSTS } from '~/graphql/queries/posts'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
@@ -19,8 +18,9 @@ function WritingPostPage({ slug }) {
 }
 
 export async function getServerSideProps({ params: { slug }, req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   const { data } = await apolloClient.query({
     query: GET_POST,

--- a/src/pages/writing/atom.tsx
+++ b/src/pages/writing/atom.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { getContext } from '~/graphql/context'
 import { GET_POSTS } from '~/graphql/queries/posts'
 import { initApolloClient } from '~/lib/apollo'
 import { generateRSS } from '~/lib/rss'
@@ -8,8 +7,9 @@ import { generateRSS } from '~/lib/rss'
 const AtomFeed: React.FC = () => null
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
   const {
     data: { posts },
   } = await apolloClient.query({

--- a/src/pages/writing/feed.tsx
+++ b/src/pages/writing/feed.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { getContext } from '~/graphql/context'
 import { GET_POSTS } from '~/graphql/queries/posts'
 import { initApolloClient } from '~/lib/apollo'
 import { generateRSS } from '~/lib/rss'
@@ -8,8 +7,9 @@ import { generateRSS } from '~/lib/rss'
 const JSONFeed: React.FC = () => null
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
   const {
     data: { posts },
   } = await apolloClient.query({

--- a/src/pages/writing/index.tsx
+++ b/src/pages/writing/index.tsx
@@ -5,7 +5,6 @@ import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { withProviders } from '~/components/Providers/withProviders'
 import { PostsList } from '~/components/Writing/PostsList'
 import routes from '~/config/routes'
-import { getContext } from '~/graphql/context'
 import { GET_POSTS } from '~/graphql/queries/posts'
 import { GET_VIEWER } from '~/graphql/queries/viewer'
 import { addApolloState, initApolloClient } from '~/lib/apollo'
@@ -21,8 +20,9 @@ function WritingPage() {
 }
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   await Promise.all([
     apolloClient.query({ query: GET_VIEWER }),

--- a/src/pages/writing/new.tsx
+++ b/src/pages/writing/new.tsx
@@ -4,7 +4,6 @@ import { ListDetailView, SiteLayout } from '~/components/Layouts'
 import { Detail } from '~/components/ListDetail/Detail'
 import { withProviders } from '~/components/Providers/withProviders'
 import { PostEditor } from '~/components/Writing/Editor/PostEditor'
-import { getContext } from '~/graphql/context'
 import { useViewerQuery } from '~/graphql/types.generated'
 import { addApolloState, initApolloClient } from '~/lib/apollo'
 
@@ -15,8 +14,9 @@ function NewPostPage() {
 }
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
 
   return addApolloState(apolloClient, {
     props: {},

--- a/src/pages/writing/rss.tsx
+++ b/src/pages/writing/rss.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { getContext } from '~/graphql/context'
 import { GET_POSTS } from '~/graphql/queries/posts'
 import { initApolloClient } from '~/lib/apollo'
 import { generateRSS } from '~/lib/rss'
@@ -8,8 +7,9 @@ import { generateRSS } from '~/lib/rss'
 const RSSFeed: React.FC = () => null
 
 export async function getServerSideProps({ req, res }) {
-  const context = await getContext(req, res)
-  const apolloClient = initApolloClient({ context })
+  const apolloClient = initApolloClient({
+    headers: { cookie: req.headers.cookie ?? '' },
+  })
   const {
     data: { posts },
   } = await apolloClient.query({


### PR DESCRIPTION
## Summary
- The SSR Apollo client (HttpLink after the SchemaLink removal) ran in Node
  without a cookie jar — outbound requests to /api/graphql arrived with no
  Cookie header, so getSession() returned null and the SSR cache hydrated
  with viewer: null. The client then read the cached null and never
  refetched, so authenticated users appeared signed-out on first paint
  after the Twitter OAuth callback.
- Forward req.headers.cookie from getServerSideProps into the SSR HttpLink's
  headers so session lookup sees the cookie.
- Drop the vestigial `context` arg from initApolloClient / createApolloClient
  — every caller passed it but it was never used inside.

## Test plan
- [x] npx tsc --noEmit clean
- [x] npm run build green
- [ ] Manual (must verify before merge): sign in with Twitter → land back
      on the site → "Sign In" is replaced with the user's avatar/menu
      without a manual refresh
- [ ] Manual: hard-refresh the home page while logged in → still shows
      signed-in state on first paint
- [ ] Manual: sign out → "Sign In" reappears
- [ ] Manual: anonymous browsing still renders pages for logged-out users