### PR TITLE
fix(images): use Cloudflare v2 direct_upload + handle errors

### DIFF
--- a/src/components/Dropzone/index.tsx
+++ b/src/components/Dropzone/index.tsx
@@ -16,18 +16,30 @@ export function Dropzone(props: DropzoneProps) {
   const { children, onUploadComplete, onUploadStarted, onUploadFailed } = props
 
   async function getSignedUrl() {
-    const data = await fetch('/api/images/sign').then((res) => res.json())
-    return data?.uploadURL
+    const res = await fetch('/api/images/sign')
+    if (!res.ok) {
+      const detail = await res.json().catch(() => null)
+      console.error('[Dropzone] sign endpoint failed', res.status, detail)
+      return null
+    }
+    const data = await res.json()
+    return data?.uploadURL ?? null
   }
 
   async function uploadFile({ file, signedUrl }) {
     const data = new FormData()
     data.append('file', file)
-    const upload = await fetch(signedUrl, {
+    const r = await fetch(signedUrl, {
       method: 'POST',
       body: data,
-    }).then((r) => r.json())
-    return upload?.result?.id
+    })
+    if (!r.ok) {
+      const detail = await r.json().catch(() => null)
+      console.error('[Dropzone] Cloudflare upload failed', r.status, detail)
+      return null
+    }
+    const upload = await r.json()
+    return upload?.result?.id ?? null
   }
 
   const onDropAccepted = React.useCallback(async (acceptedFiles: File[]) => {

--- a/src/components/Stack/StackImageUploader.tsx
+++ b/src/components/Stack/StackImageUploader.tsx
@@ -12,18 +12,38 @@ export function StackImageUploader({ stack, onImageUploaded }) {
   const [previewImage, setPreviewImage] = useState(null)
 
   async function getSignedUrl() {
-    const data = await fetch('/api/images/sign').then((res) => res.json())
-    return data?.uploadURL
+    const res = await fetch('/api/images/sign')
+    if (!res.ok) {
+      const detail = await res.json().catch(() => null)
+      console.error(
+        '[StackImageUploader] sign endpoint failed',
+        res.status,
+        detail
+      )
+      return null
+    }
+    const data = await res.json()
+    return data?.uploadURL ?? null
   }
 
   async function uploadFile({ file, signedUrl }) {
     const data = new FormData()
     data.append('file', file)
-    const upload = await fetch(signedUrl, {
+    const r = await fetch(signedUrl, {
       method: 'POST',
       body: data,
-    }).then((r) => r.json())
-    return upload?.result?.id
+    })
+    if (!r.ok) {
+      const detail = await r.json().catch(() => null)
+      console.error(
+        '[StackImageUploader] Cloudflare upload failed',
+        r.status,
+        detail
+      )
+      return null
+    }
+    const upload = await r.json()
+    return upload?.result?.id ?? null
   }
 
   const onDrop = useCallback(async (acceptedFiles) => {

--- a/src/pages/api/images/sign.ts
+++ b/src/pages/api/images/sign.ts
@@ -1,43 +1,58 @@
 import { getSession } from '@auth0/nextjs-auth0'
-import fetch from 'isomorphic-unfetch'
-import { NextApiRequest, NextApiResponse } from 'next'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
 import { UserRole } from '~/graphql/types.generated'
 import { prisma } from '~/lib/prisma'
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
-  async function isAuthenticated(req, res) {
-    const session = await getSession(req, res)
-    return session?.user
+async function isAdmin(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getSession(req, res)
+  const sub = session?.user?.sub
+  if (!sub) return false
+  const viewer = await prisma.user.findUnique({ where: { twitterId: sub } })
+  return viewer?.role === UserRole.Admin
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!(await isAdmin(req, res))) {
+    return res.status(401).json({ error: 'Unauthorized' })
   }
 
-  async function getIsAdmin(req, res) {
-    const user = await isAuthenticated(req, res)
-    if (!user) return false
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+  const apiKey = process.env.CLOUDFLARE_IMAGES_KEY
+  if (!accountId || !apiKey) {
+    console.error(
+      '[images/sign] missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_IMAGES_KEY'
+    )
+    return res.status(503).json({ error: 'Image uploads not configured' })
+  }
 
-    const viewer = await prisma.user.findUnique({
-      where: { twitterId: user.sub },
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/images/v2/direct_upload`
+
+  try {
+    const cfRes = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: new FormData(),
     })
 
-    return viewer.role === UserRole.Admin
+    const data = await cfRes.json().catch(() => null)
+
+    if (!cfRes.ok || !data?.success || !data?.result?.uploadURL) {
+      console.error('[images/sign] Cloudflare error', {
+        status: cfRes.status,
+        body: data,
+      })
+      return res
+        .status(502)
+        .json({ error: 'Failed to obtain upload URL from Cloudflare' })
+    }
+
+    return res.status(200).json({ uploadURL: data.result.uploadURL })
+  } catch (err) {
+    console.error('[images/sign] unexpected error', err)
+    return res.status(500).json({ error: 'Internal error' })
   }
-
-  const isAdmin = await getIsAdmin(req, res)
-  if (!isAdmin) {
-    return res.status(401).json({ uploadURL: null })
-  }
-
-  const CLOUDFLARE_URL = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}/images/v1/direct_upload`
-  const headers = {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${process.env.CLOUDFLARE_IMAGES_KEY}`,
-  }
-
-  const data = await fetch(CLOUDFLARE_URL, { method: 'POST', headers }).then(
-    (res) => res.json()
-  )
-
-  const { uploadURL } = data.result
-
-  return res.status(200).json({ uploadURL })
 }


### PR DESCRIPTION
## Summary
- `/api/images/sign` was hitting Cloudflare's v1 `direct_upload` with `Content-Type: application/json` and no body. Cloudflare Direct Upload requires `multipart/form-data`, so it returned `{success: false}` and the handler threw destructuring `data.result.uploadURL`, producing a 500 HTML page. Both client callers then `res.json()`'d the HTML and surfaced a `SyntaxError`, stranding the upload spinner.
- Switch the endpoint to `/images/v2/direct_upload` with `body: new FormData()` (multipart with auto-set boundary), validate env up front, wrap in try/catch, always respond with JSON, and null-safe the admin check.
- Guard `res.ok` in `Dropzone` and `StackImageUploader` before `res.json()` so failures log detail and return `null` rather than throw.

## Why
The v1 endpoint with the wrong content-type silently broke admin image upload. The cascading `SyntaxError` made the failure invisible. Switching to v2 with empty `FormData` matches Cloudflare's current contract; client guards prevent the same class of HTML-as-JSON bug from reaching users.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` green
- [ ] **Manual verification required by repo owner on production after deploy:** log in as admin, open a Stack image uploader (add or edit), drop an image — spinner resolves and image renders.
- [ ] With env unset locally: `curl /api/images/sign` returns `503 {"error":"Image uploads not configured"}`.
- [ ] Unauthenticated: `curl /api/images/sign` returns `401 {"error":"Unauthorized"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)