### PR TITLE
feat(photographs): add white frame and breathing room to gallery

### DIFF
--- a/src/components/Photographs/PhotographDetail.tsx
+++ b/src/components/Photographs/PhotographDetail.tsx
@@ -74,16 +74,18 @@ export function PhotographDetail({ slug }) {
 
         <Detail.ContentContainer>
           <Detail.Header>
-            <div className="overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-900">
-              <Image
-                priority
-                src={photograph.imageUrl}
-                width={photograph.width}
-                height={photograph.height}
-                alt={photograph.title}
-                sizes="(max-width: 768px) 100vw, 768px"
-                className="h-auto w-full"
-              />
+            <div className="rounded-xl bg-white p-2 shadow-sm md:p-3">
+              <div className="overflow-hidden rounded-md">
+                <Image
+                  priority
+                  src={photograph.imageUrl}
+                  width={photograph.width}
+                  height={photograph.height}
+                  alt={photograph.title}
+                  sizes="(max-width: 768px) 100vw, 768px"
+                  className="h-auto w-full"
+                />
+              </div>
             </div>
 
             <div className="flex flex-col space-y-2">

--- a/src/components/Photographs/PhotographListItem.tsx
+++ b/src/components/Photographs/PhotographListItem.tsx
@@ -15,19 +15,21 @@ export const PhotographListItem = React.memo<Props>(
       <Link
         href="/photographs/[slug]"
         as={`/photographs/${photograph.slug}`}
-        className={`relative block aspect-square overflow-hidden rounded-xl ${
+        className={`relative block aspect-square rounded-xl bg-white p-1.5 shadow-sm transition-shadow hover:shadow-md ${
           active
             ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-white dark:ring-offset-gray-900'
             : ''
         }`}
       >
-        <Image
-          src={photograph.imageUrl}
-          alt={photograph.title}
-          fill
-          sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
-          className="object-cover"
-        />
+        <div className="relative h-full w-full overflow-hidden rounded-md">
+          <Image
+            src={photograph.imageUrl}
+            alt={photograph.title}
+            fill
+            sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+            className="object-cover"
+          />
+        </div>
       </Link>
     )
   }

--- a/src/components/Photographs/PhotographsList.tsx
+++ b/src/components/Photographs/PhotographsList.tsx
@@ -50,7 +50,7 @@ export function PhotographsList() {
           No photographs yet.
         </div>
       ) : (
-        <div className="grid grid-cols-2 gap-1 p-3 md:grid-cols-3 lg:grid-cols-4">
+        <div className="grid grid-cols-2 gap-4 p-3 md:grid-cols-3 md:gap-5 lg:grid-cols-4 lg:gap-6">
           {edges.map((edge) => {
             const active = router.query.slug === edge.node.slug
             return (


### PR DESCRIPTION
## Summary

- **Grid spacing**: increased gap between gallery thumbnails from `gap-1` (4px) to `gap-4/5/6` (16/20/24px) at mobile/tablet/desktop breakpoints — photographs now have room to breathe.
- **White frame on thumbnails**: each `PhotographListItem` is now wrapped in an unconditional `bg-white p-1.5` matte with `rounded-xl` outer / `rounded-md` inner radius stacking, `shadow-sm` at rest, `hover:shadow-md` on hover (shadow transition only — no scale/transform).
- **White frame on detail view**: the `PhotographDetail` image wrapper replaces the `bg-gray-100 dark:bg-gray-900` placeholder with the same `bg-white p-2 md:p-3 shadow-sm` matte treatment.

The white frame is intentionally unconditional — no dark-mode override — because the print-on-dark-background effect is the design goal.

## What reviewers should know

- `bg-white` does not vary with color scheme; this is deliberate (white mat = print aesthetic).
- Active ring on thumbnails still works cleanly: the ring host is the outer `<Link>`, so `ring-offset-2` sits outside the white matte as expected.
- The `aspect-square` constraint lives on the `<Link>` (the frame), so the photograph + matte together form a square; the inner image area is a slightly smaller square — the visible mat.
- No changes to image rendering, upload, metadata, or any non-display code.

## Test plan

- [ ] `/photographs` — gallery has visible spacing; each thumbnail has white matte with subtle shadow; hover lifts shadow; active ring is clean
- [ ] `/photographs/[slug]` — detail photograph shown in white matte; portrait/landscape/square all render without distortion
- [ ] Dark OS theme — white frame stays white (intentional)
- [ ] Mobile (≤640px) — no horizontal scroll introduced by increased gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)