### PR TITLE
fix(photographs): remove rounded corners from white frames

### DIFF
--- a/src/components/Photographs/PhotographDetail.tsx
+++ b/src/components/Photographs/PhotographDetail.tsx
@@ -74,8 +74,8 @@ export function PhotographDetail({ slug }) {
 
         <Detail.ContentContainer>
           <Detail.Header>
-            <div className="rounded-xl bg-white p-2 shadow-sm md:p-3">
-              <div className="overflow-hidden rounded-md">
+            <div className="bg-white p-2 shadow-sm md:p-3">
+              <div className="overflow-hidden">
                 <Image
                   priority
                   src={photograph.imageUrl}

--- a/src/components/Photographs/PhotographListItem.tsx
+++ b/src/components/Photographs/PhotographListItem.tsx
@@ -15,13 +15,13 @@ export const PhotographListItem = React.memo<Props>(
       <Link
         href="/photographs/[slug]"
         as={`/photographs/${photograph.slug}`}
-        className={`relative block aspect-square rounded-xl bg-white p-1.5 shadow-sm transition-shadow hover:shadow-md ${
+        className={`relative block aspect-square bg-white p-1.5 shadow-sm transition-shadow hover:shadow-md ${
           active
             ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-white dark:ring-offset-gray-900'
             : ''
         }`}
       >
-        <div className="relative h-full w-full overflow-hidden rounded-md">
+        <div className="relative h-full w-full overflow-hidden">
           <Image
             src={photograph.imageUrl}
             alt={photograph.title}


### PR DESCRIPTION
## Summary

- Removes `rounded-xl` from the outer frame wrapper and `rounded-md` from the inner image well in both the gallery thumbnail and detail view.
- Frames now have straight edges — sharp rectangle, no border radius.

Follow-up to #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)